### PR TITLE
Fixing error due to removed pip option on setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 # command to install dependencies
 install:
     - pip3 install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp35-cp35m-linux_x86_64.whl
-    - pip3 install --process-dependency-links --editable .
+    - pip3 install --editable .
     - pip3 install flake8
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ cache: pip
 python:
     - "3.5"
 
+before_install:
+    - pip3 install --upgrade pip
+
 # command to install dependencies
 install:
     - pip3 install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp35-cp35m-linux_x86_64.whl
+    - pip3 
     - pip3 install --editable .
     - pip3 install flake8
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, clone this repository and install the other dependencies with `pip3`:
 ```
 git clone https://github.com/mila-udem/babyai.git
 cd babyai
-pip3 install --process-dependency-links --editable .
+pip3 install --editable .
 ```
 
 ### Installation using Conda (Alternative Method)

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ To run the interactive GUI application that illustrates the platform:
 scripts/gui.py
 ```
 
-The level being run can be selected with the `--env-name` option, eg:
+The level being run can be selected with the `--env` option, eg:
 
 ```
-scripts/gui.py --env-name BabyAI-UnlockPickup-v0
+scripts/gui.py --env BabyAI-UnlockPickup-v0
 ```
 
 ### Training

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,7 @@ setup(
         'numpy==1.15.4', # Temporary: fix numpy version because of bug introduced in 1.16
         'pyqt5>=5.10.1',
         "torch>=0.4.1",
-        'gym_minigrid',
-        'blosc>=1.5.1'
+        'blosc>=1.5.1',
+        'gym_minigrid @ https://github.com/maximecb/gym-minigrid/archive/master.zip'
     ],
-    dependency_links=[
-        'git+https://github.com/maximecb/gym-minigrid.git#egg=gym_minigrid-0',
-    ]
 )


### PR DESCRIPTION
The option `--process-dependency-links` was removed from `pip` and it is now showing an error, this PR will remove the option from the docs and update the `setup.py` to use the specification from [PEP-0508](https://www.python.org/dev/peps/pep-0508/#examples).

It also fixes an incorrect parameter name in the documentation.