### PR TITLE
Separate --save-interval value for IL and RL

### DIFF
--- a/babyai/arguments.py
+++ b/babyai/arguments.py
@@ -31,8 +31,6 @@ class ArgumentParser(argparse.ArgumentParser):
         # Training arguments
         self.add_argument("--log-interval", type=int, default=10,
                             help="number of updates between two logs (default: 10)")
-        self.add_argument("--save-interval", type=int, default=1,
-                            help="number of updates between two saves (default: 1, 0 means no saving)")
         self.add_argument("--frames", type=int, default=int(9e10),
                             help="number of frames of training (default: 9e10)")
         self.add_argument("--patience", type=int, default=100,

--- a/scripts/train_il.py
+++ b/scripts/train_il.py
@@ -35,7 +35,7 @@ parser.add_argument("--multi-demos", nargs='*', default=None,
 parser.add_argument("--multi-episodes", type=int, nargs='*', default=None,
                     help="number of episodes of demos to use from each file (REQUIRED when multi-env is specified)")
 parser.add_argument("--save-interval", type=int, default=1,
-                    help="number of updates between two saves (default: 1, 0 means no saving)")
+                    help="number of epochs between two saves (default: 1, 0 means no saving)")
 
 
 def main(args):

--- a/scripts/train_il.py
+++ b/scripts/train_il.py
@@ -34,6 +34,8 @@ parser.add_argument("--multi-demos", nargs='*', default=None,
                     help="demos filenames for envs to train on (REQUIRED when multi-env is specified)")
 parser.add_argument("--multi-episodes", type=int, nargs='*', default=None,
                     help="number of episodes of demos to use from each file (REQUIRED when multi-env is specified)")
+parser.add_argument("--save-interval", type=int, default=1,
+                    help="number of updates between two saves (default: 1, 0 means no saving)")
 
 
 def main(args):

--- a/scripts/train_intelligent_expert.py
+++ b/scripts/train_intelligent_expert.py
@@ -53,6 +53,9 @@ parser.add_argument("--num-eval-demos", type=int, default=1000,
                     help="number of demos used for evaluation while growing the training set")
 parser.add_argument("--phases", type=int, default=1000,
                     help="maximum number of phases to train for")
+parser.add_argument("--save-interval", type=int, default=1,
+                    help="number of updates between two saves (default: 1, 0 means no saving)")
+
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/train_intelligent_expert.py
+++ b/scripts/train_intelligent_expert.py
@@ -54,7 +54,7 @@ parser.add_argument("--num-eval-demos", type=int, default=1000,
 parser.add_argument("--phases", type=int, default=1000,
                     help="maximum number of phases to train for")
 parser.add_argument("--save-interval", type=int, default=1,
-                    help="number of updates between two saves (default: 1, 0 means no saving)")
+                    help="number of epochs between two saves (default: 1, 0 means no saving)")
 
 
 logger = logging.getLogger(__name__)

--- a/scripts/train_rl.py
+++ b/scripts/train_rl.py
@@ -42,6 +42,8 @@ parser.add_argument("--clip-eps", type=float, default=0.2,
                     help="clipping epsilon for PPO (default: 0.2)")
 parser.add_argument("--ppo-epochs", type=int, default=4,
                     help="number of epochs for PPO (default: 4)")
+parser.add_argument("--save-interval", type=int, default=50,
+                    help="number of updates between two saves (default: 50, 0 means no saving)")
 args = parser.parse_args()
 
 utils.seed(args.seed)


### PR DESCRIPTION
The new default value of --save-interval 1 makes RL training about 10x slower. We need to have different values for IL and RL.