### PR TITLE
fix wide variance in success rate

### DIFF
--- a/babyai/evaluate.py
+++ b/babyai/evaluate.py
@@ -83,7 +83,6 @@ class ManyEnvs(gym.Env):
 # Returns the performance of the agent on the environment for a particular number of episodes.
 def batch_evaluate(agent, env_name, seed, episodes, return_obss_actions=False):
     num_envs = min(256, episodes)
-    # num_envs = 1
 
     envs = []
     for i in range(num_envs):

--- a/babyai/evaluate.py
+++ b/babyai/evaluate.py
@@ -83,6 +83,7 @@ class ManyEnvs(gym.Env):
 # Returns the performance of the agent on the environment for a particular number of episodes.
 def batch_evaluate(agent, env_name, seed, episodes, return_obss_actions=False):
     num_envs = min(256, episodes)
+    # num_envs = 1
 
     envs = []
     for i in range(num_envs):
@@ -114,10 +115,10 @@ def batch_evaluate(agent, env_name, seed, episodes, return_obss_actions=False):
         while (num_frames == 0).any():
             action = agent.act_batch(many_obs)['action']
             if return_obss_actions:
-                for _ in range(num_envs):
-                    if not already_done[_]:
-                        obss[_].append(many_obs[_])
-                        actions[_].append(action[_].item())
+                for i in range(num_envs):
+                    if not already_done[i]:
+                        obss[i].append(many_obs[i])
+                        actions[i].append(action[i].item())
             many_obs, reward, done, _ = env.step(action)
             agent.analyze_feedback(reward, done)
             done = np.array(done)

--- a/babyai/model.py
+++ b/babyai/model.py
@@ -256,6 +256,8 @@ class ACModel(nn.Module, babyai.rl.RecurrentACModel):
     def _get_instr_embedding(self, instr):
         if self.lang_model == 'gru':
             _, hidden = self.instr_rnn(self.word_embedding(instr))
+            x = (instr <= 0).sum(dim=1)
+            print(x)
             return hidden[-1]
 
         elif self.lang_model in ['bigru', 'attgru']:

--- a/babyai/model.py
+++ b/babyai/model.py
@@ -254,14 +254,13 @@ class ACModel(nn.Module, babyai.rl.RecurrentACModel):
         return {'dist': dist, 'value': value, 'memory': memory, 'extra_predictions': extra_predictions}
 
     def _get_instr_embedding(self, instr):
+        lengths = (instr != 0).sum(1).long()
         if self.lang_model == 'gru':
             out, _ = self.instr_rnn(self.word_embedding(instr))
-            index = -1 - (instr <= 0).sum(dim=1)
-            hidden = out[range(len(index)), index, :]
+            hidden = out[range(len(lengths)), lengths-1, :]
             return hidden
 
         elif self.lang_model in ['bigru', 'attgru']:
-            lengths = (instr != 0).sum(1).long()
             masks = (instr != 0).float()
 
             if lengths.shape[0] > 1:

--- a/babyai/model.py
+++ b/babyai/model.py
@@ -255,10 +255,10 @@ class ACModel(nn.Module, babyai.rl.RecurrentACModel):
 
     def _get_instr_embedding(self, instr):
         if self.lang_model == 'gru':
-            _, hidden = self.instr_rnn(self.word_embedding(instr))
-            x = (instr <= 0).sum(dim=1)
-            print(x)
-            return hidden[-1]
+            out, _ = self.instr_rnn(self.word_embedding(instr))
+            index = -1 - (instr <= 0).sum(dim=1)
+            hidden = out[range(len(index)), index, :]
+            return hidden
 
         elif self.lang_model in ['bigru', 'attgru']:
             lengths = (instr != 0).sum(1).long()


### PR DESCRIPTION
The success rate computed by `scripts/evaluate.py` has a wide variance with respect to the batch size (`num_envs` evaluated per time).

This is caused by variable-length instruction padding. The variable length changes the output from a unidirectional GRU. Padding should not change the embedding value.

This was fixed by taking the output of the GRU computed before the first zero in the input sequence appears (pad value).