### PR TITLE
Only mention docker image in ICLR19 branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Build Status](https://travis-ci.org/mila-iqia/babyai.svg?branch=master)](https://travis-ci.org/mila-iqia/babyai)
 
-A platform for simulating language learning with a human in the loop. This is an ongoing research project based at [Mila](https://mila.quebec/en/). 
+A platform for simulating language learning with a human in the loop. This is an ongoing research project based at [Mila](https://mila.quebec/en/).
 
 Contents:
 - [Citation](#citation)
+- [Replicating ICLR19 Results](#replicating-iclr19-results)
 - [Installation](#installation)
 - [Usage](#usage)
-- [Demo Dataset](docs/demo-dataset.md)
 - [Codebase Structure](docs/codebase.md)
 - [Levels](#the-levels)
 - [Training and Evaluation](docs/train-eval.md)
@@ -29,6 +29,10 @@ If you use this platform in your research, please cite:
   url={https://openreview.net/forum?id=rJeXCo0cYX},
 }
 ```
+
+## Replicating ICLR19 Results
+
+The master branch of this repository is updated frequently. If you are looking to replicate or compare against the results from the [ICLR19 BabyAI paper](https://openreview.net/forum?id=rJeXCo0cYX), please use the docker image, demonstration dataset and source code from the [iclr19 branch](https://github.com/mila-iqia/babyai/tree/iclr19) of this repository.
 
 ## Installation
 
@@ -77,22 +81,6 @@ cd ../babyai
 pip install --editable .
 ```
 
-### Docker Image
-
-A prebuilt docker image is available [on Docker Hub](https://hub.docker.com/r/maximecb/babyai/). You can download this image by executing:
-
-```
-docker pull maximecb/babyai
-```
-
-You should run the image with `nvidia-docker` (which allows you to use CUDA):
-
-```
-nvidia-docker run -it maximecb/babyai bash
-```
-
-Pretrained IL and RL models can be found in the `models` directory of the image.
-
 ### BabyAI Storage Path
 
 Add this line to `.bashrc` (Linux), or `.bash_profile` (Mac).
@@ -125,7 +113,6 @@ Documentation for the ICLR19 levels can be found in
 [docs/iclr19_levels.md](docs/iclr19_levels.md).
 There are also older levels documented in
 [docs/bonus_levels.md](docs/bonus_levels.md).
-
 
 ## About this Project
 

--- a/docs/demo-dataset.md
+++ b/docs/demo-dataset.md
@@ -1,7 +1,0 @@
-# Demonstration Dataset
-
-**NOTE 2018-10-18:** we are in the process of improving the heuristic agent (bot) and will be releasing a new dataset of higher-quality demonstrations soon.
-
-Generating demonstrations takes a sizeable amount of computational resources. A gzipped archive containing the demonstrations used for the ICLR 2019 submission is [available here](http://lisaweb.iro.umontreal.ca/transfert/lisa/users/chevalma/iclr19-demos.tar.gz) (14GB download). Please note that these demonstrations can only be used with the ICLR 2019 [docker image](https://github.com/mila-iqia/babyai#docker-image) as they are no longer compatible with the source code on the master branch of this repository. If you wish to work with latest BabyAI source code, you should generate a new demonstration dataset.
-
-Once downloaded, extract the `.pkl` files to `/<PATH>/<TO>/<BABYAI>/<REPOSITORY>/<PARENT>/demos`.


### PR DESCRIPTION
I'd like to avoid a frequent source of confusion, which is people
trying to use the docker image and demo dataset with code from
the master branch (which doesn't work). Instead, I propose we
have a link to the iclr19 branch on master, and only link to
the docker and demo dataset from the iclr19 branch.