### PR TITLE
Values returned from max and sample now same shape

### DIFF
--- a/babyai/utils/agent.py
+++ b/babyai/utils/agent.py
@@ -63,7 +63,7 @@ class ModelAgent(Agent):
             self.memory = model_results['memory']
 
         if self.argmax:
-            action = dist.probs.max(1, keepdim=True)[1]
+            action = dist.probs.max(1, keepdim=True)[1][:, 0]
         else:
             action = dist.sample()
 

--- a/babyai/utils/agent.py
+++ b/babyai/utils/agent.py
@@ -63,7 +63,7 @@ class ModelAgent(Agent):
             self.memory = model_results['memory']
 
         if self.argmax:
-            action = dist.probs.max(1, keepdim=True)[1][:, 0]
+            action = dist.probs.argmax(1)
         else:
             action = dist.sample()
 


### PR DESCRIPTION
`dist.probs.max(1, keepdim=True)[1]` returns shape `(batch_size, 1)`
`dist.sample()` returns `(batch_size)`

Adding `[:, 0]` ensures to the first ensures that the returned shape is always `(batch_size)`.