### PR TITLE
Load model to CPU if CUDA unavailable

### DIFF
--- a/babyai/utils/model.py
+++ b/babyai/utils/model.py
@@ -15,7 +15,10 @@ def get_model_path(model_name):
 def load_model(model_name, raise_not_found=True):
     path = get_model_path(model_name)
     try:
-        model = torch.load(path)
+        if torch.cuda.is_available():
+            model = torch.load(path)
+        else:
+            model = torch.load(path, map_location=torch.device("cpu"))
         model.eval()
         return model
     except FileNotFoundError:


### PR DESCRIPTION
I train my BabyAI models using CUDA, but sometimes I want to load the resulting models on a computer where CUDA is unavailable. I've had to make this small change to make that work and thought this might be useful for others as well.