### PR TITLE
Fix incorrect column row order

### DIFF
--- a/babyai/levels/iclr19_levels.py
+++ b/babyai/levels/iclr19_levels.py
@@ -435,7 +435,7 @@ class Level_Unlock(RoomGridLevel):
             jk = self._rand_int(0, self.num_rows)
             if ik is id and jk is jd:
                 continue
-            self.add_object(jk, ik, 'key', door.color)
+            self.add_object(ik, jk, 'key', door.color)
             break
 
         # With 50% probability, ensure that the locked door is the only

--- a/babyai/levels/iclr19_levels.py
+++ b/babyai/levels/iclr19_levels.py
@@ -312,8 +312,8 @@ class Level_GoToImpUnlock(RoomGridLevel):
         # Add a locked door to a random room
         id = self._rand_int(0, self.num_rows)
         jd = self._rand_int(0, self.num_cols)
-        door, pos = self.add_door(id, jd, locked=True)
-        locked_room = self.get_room(id, jd)
+        door, pos = self.add_door(jd, id, locked=True)
+        locked_room = self.get_room(jd, id)
 
         # Add the key to a different room
         while True:
@@ -321,7 +321,7 @@ class Level_GoToImpUnlock(RoomGridLevel):
             jk = self._rand_int(0, self.num_cols)
             if ik is id and jk is jd:
                 continue
-            self.add_object(ik, jk, 'key', door.color)
+            self.add_object(jk, ik, 'key', door.color)
             break
 
         self.connect_all()
@@ -406,7 +406,7 @@ class Level_Open(RoomGridLevel):
         doors = []
         for i in range(self.num_rows):
             for j in range(self.num_cols):
-                room = self.get_room(i, j)
+                room = self.get_room(j, i)
                 for door in room.doors:
                     if door:
                         doors.append(door)
@@ -426,8 +426,8 @@ class Level_Unlock(RoomGridLevel):
         # Add a locked door to a random room
         id = self._rand_int(0, self.num_rows)
         jd = self._rand_int(0, self.num_cols)
-        door, pos = self.add_door(id, jd, locked=True)
-        locked_room = self.get_room(id, jd)
+        door, pos = self.add_door(jd, id, locked=True)
+        locked_room = self.get_room(jd, id)
 
         # Add the key to a different room
         while True:
@@ -435,7 +435,7 @@ class Level_Unlock(RoomGridLevel):
             jk = self._rand_int(0, self.num_cols)
             if ik is id and jk is jd:
                 continue
-            self.add_object(ik, jk, 'key', door.color)
+            self.add_object(jk, ik, 'key', door.color)
             break
 
         # With 50% probability, ensure that the locked door is the only

--- a/babyai/levels/iclr19_levels.py
+++ b/babyai/levels/iclr19_levels.py
@@ -310,18 +310,18 @@ class Level_GoToImpUnlock(RoomGridLevel):
 
     def gen_mission(self):
         # Add a locked door to a random room
-        id = self._rand_int(0, self.num_rows)
-        jd = self._rand_int(0, self.num_cols)
-        door, pos = self.add_door(jd, id, locked=True)
-        locked_room = self.get_room(jd, id)
+        id = self._rand_int(0, self.num_cols)
+        jd = self._rand_int(0, self.num_rows)
+        door, pos = self.add_door(id, jd, locked=True)
+        locked_room = self.get_room(id, jd)
 
         # Add the key to a different room
         while True:
-            ik = self._rand_int(0, self.num_rows)
-            jk = self._rand_int(0, self.num_cols)
+            ik = self._rand_int(0, self.num_cols)
+            jk = self._rand_int(0, self.num_rows)
             if ik is id and jk is jd:
                 continue
-            self.add_object(jk, ik, 'key', door.color)
+            self.add_object(ik, jk, 'key', door.color)
             break
 
         self.connect_all()
@@ -330,8 +330,8 @@ class Level_GoToImpUnlock(RoomGridLevel):
         # We do this to speed up the reachability test,
         # which otherwise will reject all levels with
         # objects in the locked room.
-        for i in range(self.num_rows):
-            for j in range(self.num_cols):
+        for i in range(self.num_cols):
+            for j in range(self.num_rows):
                 if i is not id or j is not jd:
                     self.add_distractors(
                         i,
@@ -404,9 +404,9 @@ class Level_Open(RoomGridLevel):
 
         # Collect a list of all the doors in the environment
         doors = []
-        for i in range(self.num_rows):
-            for j in range(self.num_cols):
-                room = self.get_room(j, i)
+        for i in range(self.num_cols):
+            for j in range(self.num_rows):
+                room = self.get_room(i, j)
                 for door in room.doors:
                     if door:
                         doors.append(door)
@@ -424,15 +424,15 @@ class Level_Unlock(RoomGridLevel):
 
     def gen_mission(self):
         # Add a locked door to a random room
-        id = self._rand_int(0, self.num_rows)
-        jd = self._rand_int(0, self.num_cols)
-        door, pos = self.add_door(jd, id, locked=True)
-        locked_room = self.get_room(jd, id)
+        id = self._rand_int(0, self.num_cols)
+        jd = self._rand_int(0, self.num_rows)
+        door, pos = self.add_door(id, jd, locked=True)
+        locked_room = self.get_room(id, jd)
 
         # Add the key to a different room
         while True:
-            ik = self._rand_int(0, self.num_rows)
-            jk = self._rand_int(0, self.num_cols)
+            ik = self._rand_int(0, self.num_cols)
+            jk = self._rand_int(0, self.num_rows)
             if ik is id and jk is jd:
                 continue
             self.add_object(jk, ik, 'key', door.color)
@@ -450,8 +450,8 @@ class Level_Unlock(RoomGridLevel):
         # We do this to speed up the reachability test,
         # which otherwise will reject all levels with
         # objects in the locked room.
-        for i in range(self.num_rows):
-            for j in range(self.num_cols):
+        for i in range(self.num_cols):
+            for j in range(self.num_rows):
                 if i is not id or j is not jd:
                     self.add_distractors(
                         i,

--- a/babyai/levels/levelgen.py
+++ b/babyai/levels/levelgen.py
@@ -108,9 +108,9 @@ class RoomGridLevel(RoomGrid):
         # Gather the colors of locked doors
         if hasattr(self, 'unblocking') and self.unblocking:
             colors_of_locked_doors = []
-            for i in range(self.num_rows):
-                for j in range(self.num_cols):
-                    room = self.get_room(j, i)
+            for i in range(self.num_cols):
+                for j in range(self.num_rows):
+                    room = self.get_room(i, j)
                     for door in room.doors:
                         if door and door.is_locked:
                             colors_of_locked_doors.append(door.color)
@@ -191,9 +191,9 @@ class RoomGridLevel(RoomGrid):
         Open all the doors in the maze
         """
 
-        for i in range(self.num_rows):
-            for j in range(self.num_cols):
-                room = self.get_room(j, i)
+        for i in range(self.num_cols):
+            for j in range(self.num_rows):
+                room = self.get_room(i, j)
                 for door in room.doors:
                     if door:
                         door.is_open = True

--- a/babyai/levels/levelgen.py
+++ b/babyai/levels/levelgen.py
@@ -110,7 +110,7 @@ class RoomGridLevel(RoomGrid):
             colors_of_locked_doors = []
             for i in range(self.num_rows):
                 for j in range(self.num_cols):
-                    room = self.get_room(i, j)
+                    room = self.get_room(j, i)
                     for door in room.doors:
                         if door and door.is_locked:
                             colors_of_locked_doors.append(door.color)
@@ -193,7 +193,7 @@ class RoomGridLevel(RoomGrid):
 
         for i in range(self.num_rows):
             for j in range(self.num_cols):
-                room = self.get_room(i, j)
+                room = self.get_room(j, i)
                 for door in room.doors:
                     if door:
                         door.is_open = True


### PR DESCRIPTION
For `RoomGrid.get_room(i, j)`, `RoomGrid.add_door(i, j, ...)`, `RoomGrid.add_object(i, j, ...)`, `i` should be column, `j` should be row.

Switching the order can cause crash if num_rows is not same as num_cols.