### PR TITLE
BabyAI Bot's _find_obj_pos fn considers Wall object

### DIFF
--- a/babyai/bot.py
+++ b/babyai/bot.py
@@ -606,6 +606,8 @@ class Bot:
         best_obj = None
 
         for i in range(len(obj_desc.obj_set)):
+            if obj_desc.obj_set[i].type == 'wall':
+                continue
             try:
                 if obj_desc.obj_set[i] == self.mission.carrying:
                     continue


### PR DESCRIPTION
When the mission involves finding a 'grey object', 'wall'-typed objects can be considered, which is not a desired situation. 
The previous code was breaking in an assertion error as the returned 'shortest_path_to_obj' would end up being None.

The current fix simply ignores 'wall'-typed objects when trying to find an object that matches the ObjDesc provided  as argument to the find_obj_pos fn.