### PR TITLE
Added a deprecation notice

### DIFF
--- a/babyai/__init__.py
+++ b/babyai/__init__.py
@@ -10,6 +10,6 @@ warnings.warn(
     "(see https://github.com/Farama-Foundation/Minigrid/tree/master/minigrid/envs/babyai). \n"
     "This maintained version includes documentation, support for current versions of Python,\n"
     "numerous bug fixes, support for installation via pip, and numerous other large quality of life improvements.\n"
-    "We encourage researchers to switch to this maintained version for all purposes other than comparing "
+    "We encourage researchers to switch to this maintained version for all purposes other than comparing\n"
     "to results run on this version of the environments. \n"
 )

--- a/babyai/__init__.py
+++ b/babyai/__init__.py
@@ -2,3 +2,14 @@
 # when the babyai package is imported
 from . import levels
 from . import utils
+import warnings
+
+warnings.warn(
+    "This code base is no longer maintained, and is not expected to be maintained again in the future. \n"
+    "These environments been maintained inside of Minigrid"
+    "(see https://github.com/Farama-Foundation/Minigrid/tree/master/minigrid/envs/babyai). \n"
+    "This maintained version includes documentation, support for current versions of Python,\n"
+    "numerous bug fixes, support for installation via pip, and numerous other large quality of life improvements.\n"
+    "We encourage researchers to switch to this maintained version for all purposes other than comparing "
+    "to results run on this version of the environments. \n"
+)

--- a/babyai/__init__.py
+++ b/babyai/__init__.py
@@ -4,12 +4,13 @@ from . import levels
 from . import utils
 import warnings
 
+
 warnings.warn(
-    "This code base is no longer maintained, and is not expected to be maintained again in the future. \n"
-    "These environments been maintained inside of Minigrid"
+    "This code base is no longer maintained and is not expected to be maintained again. \n"
+    "These environments are now maintained within Minigrid"
     "(see https://github.com/Farama-Foundation/Minigrid/tree/master/minigrid/envs/babyai). \n"
-    "This maintained version includes documentation, support for current versions of Python,\n"
-    "numerous bug fixes, support for installation via pip, and numerous other large quality of life improvements.\n"
-    "We encourage researchers to switch to this maintained version for all purposes other than comparing\n"
-    "to results run on this version of the environments. \n"
+    "The maintained version includes documentation, support for current versions of Python, \n"
+    "numerous bug fixes, support for installation via pip, and many other quality-of-life improvements. \n"
+    "We encourage researchers to switch to the maintained version for all purposes other than comparing \n"
+    "with results that use this version of the environments. \n"
 )

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,16 @@
 from setuptools import setup
 
 setup(
-    name='babyai',
-    version='1.1.2',
-    license='BSD 3-clause',
-    keywords='memory, environment, agent, rl, openaigym, openai-gym, gym',
-    packages=['babyai', 'babyai.levels', 'babyai.utils'],
+    name="babyai",
+    version="1.1.2",
+    license="BSD 3-clause",
+    keywords="memory, environment, agent, rl, openaigym, openai-gym, gym",
+    packages=["babyai", "babyai.levels", "babyai.utils"],
     install_requires=[
-        'gym>=0.9.6',
-        'numpy>=1.17.0',
+        "gym>=0.9.6",
+        "numpy>=1.17.0",
         "torch>=0.4.1",
-        'blosc>=1.5.1',
-        'gym_minigrid @ https://github.com/maximecb/gym-minigrid/archive/master.zip'
+        "blosc>=1.5.1",
+        "gym_minigrid>=1.2.0",
     ],
 )


### PR DESCRIPTION
Added a deprecation notice:

> This code base is no longer maintained, and is not expected to be maintained again in the future.
> These environments been maintained inside of Minigrid
> (see https://github.com/Farama-Foundation/Minigrid/tree/master/minigrid/envs/babyai).
> This maintained version includes documentation, support for current versions of Python,
> numerous bug fixes, support for installation via pip, and numerous other large quality of life improvements.
> We encourage researchers to switch to this maintained version for all purposes other than comparing
> to results run on this version of the environments.

when importing the library.