### PR TITLE
Updating bot for compatibility with legacy and Minigrid

### DIFF
--- a/babyai/bot.py
+++ b/babyai/bot.py
@@ -294,13 +294,13 @@ class GoNextToSubgoal(Subgoal):
 
     def replan_before_action(self):
         target_obj = None
-        if isinstance(self.datum, ObjDesc):
+        if 'ObjDesc' in type(self.datum).__name__:
             target_obj, target_pos = self.bot._find_obj_pos(self.datum, self.reason == 'PutNext')
             if not target_pos:
                 # No path found -> Explore the world
                 self.bot.stack.append(ExploreSubgoal(self.bot))
                 return
-        elif isinstance(self.datum, WorldObj):
+        elif 'WorldObj' in type(self.datum).__name__:
             target_obj = self.datum
             target_pos = target_obj.cur_pos
         else:
@@ -379,7 +379,7 @@ class GoNextToSubgoal(Subgoal):
 
         # So there is a path (blocker, or non-blockers)
         # -> try following it
-        next_cell = path[0]
+        next_cell = np.asarray(path[0])
 
         # Choose the action in the case when the forward cell
         # is the one we should go next to
@@ -529,7 +529,7 @@ class Bot:
         self.grid = Grid(mission.width, mission.height)
 
         # Visibility mask. True for explored/seen, false for unexplored.
-        self.vis_mask = np.zeros(shape=(mission.width, mission.height), dtype=np.bool)
+        self.vis_mask = np.zeros(shape=(mission.width, mission.height), dtype=bool)
 
         # Stack of tasks/subtasks to complete (tuples)
         self.stack = []
@@ -904,16 +904,16 @@ class Bot:
         Translate instructions into an internal form the agent can execute
         """
 
-        if isinstance(instr, GoToInstr):
+        if 'GoToInstr' in type(instr).__name__:
             self.stack.append(GoNextToSubgoal(self, instr.desc))
             return
 
-        if isinstance(instr, OpenInstr):
+        if 'OpenInstr' in type(instr).__name__:
             self.stack.append(OpenSubgoal(self))
             self.stack.append(GoNextToSubgoal(self, instr.desc, reason='Open'))
             return
 
-        if isinstance(instr, PickupInstr):
+        if 'PickupInstr' in type(instr).__name__:
             # We pick up and immediately drop so
             # that we may carry other objects
             self.stack.append(DropSubgoal(self))
@@ -921,19 +921,20 @@ class Bot:
             self.stack.append(GoNextToSubgoal(self, instr.desc))
             return
 
-        if isinstance(instr, PutNextInstr):
+        if 'PutNextInstr' in type(instr).__name__:
             self.stack.append(DropSubgoal(self))
             self.stack.append(GoNextToSubgoal(self, instr.desc_fixed, reason='PutNext'))
             self.stack.append(PickupSubgoal(self))
             self.stack.append(GoNextToSubgoal(self, instr.desc_move))
             return
 
-        if isinstance(instr, BeforeInstr) or isinstance(instr, AndInstr):
+        if 'BeforeInstr' in type(instr).__name__ \
+        or 'AndInstr' in type(instr).__name__:
             self._process_instr(instr.instr_b)
             self._process_instr(instr.instr_a)
             return
 
-        if isinstance(instr, AfterInstr):
+        if 'AfterInstr' in type(instr).__name__:
             self._process_instr(instr.instr_a)
             self._process_instr(instr.instr_b)
             return

--- a/babyai/bot.py
+++ b/babyai/bot.py
@@ -606,6 +606,8 @@ class Bot:
         best_obj = None
 
         for i in range(len(obj_desc.obj_set)):
+            if obj_desc.obj_set[i].type == 'wall':
+                continue
             try:
                 if obj_desc.obj_set[i] == self.mission.carrying:
                     continue

--- a/babyai/levels/bonus_levels.py
+++ b/babyai/levels/bonus_levels.py
@@ -1,5 +1,6 @@
 import gym
-from gym_minigrid.envs import Key, Ball, Box
+#from gym_minigrid.envs import Key, Ball, Box
+from gym_minigrid.minigrid import Key, Ball, Box
 from .verifier import *
 from .levelgen import *
 

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ setup(
     keywords='memory, environment, agent, rl, openaigym, openai-gym, gym',
     packages=['babyai', 'babyai.levels', 'babyai.utils'],
     install_requires=[
-        'gym>=0.9.6',
-        'numpy==1.15.4', # Temporary: fix numpy version because of bug introduced in 1.16
+        'gym==0.23', # before introduction of 'truncated' extra output... (previously: >=0.9.6')
+        'numpy',
         "torch>=0.4.1",
         'blosc>=1.5.1',
-        'gym_minigrid @ https://github.com/maximecb/gym-minigrid/archive/master.zip'
+        'gym-minigrid==1.1', # before gym-minigrid became Minigrid (previously 'gym_minigrid @ https://github.com/maximecb/gym-minigrid/archive/master.zip')
     ],
 )


### PR DESCRIPTION
1) Updating bot for it to be compatible with either BabyAI benchmark in its legacy repository, and in its integration within Minigrid...

2) setup.py is updated  in order to: 
- use gym==0.23, which is before introduction of the 'truncated' output, which might be desirable for all, but at least reasonable for operability with all other legacy codebase.
- use gym-minigrid==1.1, which is before it became Minigrid and new pip does not allow its installation as specified before.